### PR TITLE
ci: fix workflow YAML syntax

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ main next ]
+    branches: [ main, next ]
   pull_request:
-    branches: [ main next ]
+    branches: [ main, next ]
 
 jobs:
 


### PR DESCRIPTION
The workflow had `[ main next ]` instead of `[ main, next ]` - missing comma means it was treated as a single invalid branch name.